### PR TITLE
skip positions that look like they have more castling rights

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -13,7 +13,7 @@ from chess import Move, Color
 from chess.engine import SimpleEngine, Mate, Cp, Score, PovScore
 from chess.pgn import Game, ChildNode
 from typing import List, Optional, Union, Set
-from util import get_next_move_pair, material_count, material_diff, is_up_in_material, win_chances
+from util import get_next_move_pair, material_count, material_diff, is_up_in_material, maximum_castling_rights, win_chances
 from server import Server
 
 version = 47
@@ -149,6 +149,9 @@ class Generator:
                 skip_until_irreversible = True
                 continue
             seen_fens.add(fen)
+
+            if board.castling_rights != maximum_castling_rights(board):
+                continue
 
             result = self.analyze_position(node, prev_score, current_eval, tier)
 

--- a/generator/util.py
+++ b/generator/util.py
@@ -20,6 +20,12 @@ def material_diff(board: Board, side: Color) -> int:
 def is_up_in_material(board: Board, side: Color) -> bool:
     return material_diff(board, side) > 0
 
+def maximum_castling_rights(board: chess.Board) -> chess.Bitboard:
+    return (
+        (board.pieces_mask(chess.ROOK, chess.WHITE) & (chess.BB_A1 | chess.BB_H1) if board.king(chess.WHITE) == chess.E1 else chess.BB_EMPTY) |
+        (board.pieces_mask(chess.ROOK, chess.BLACK) & (chess.BB_A8 | chess.BB_H8) if board.king(chess.BLACK) == chess.E8 else chess.BB_EMPTY)
+    )
+
 
 def get_next_move_pair(engine: SimpleEngine, node: GameNode, winner: Color, limit: chess.engine.Limit) -> NextMovePair:
     info = engine.analyse(node.board(), multipv = 2, limit = limit)


### PR DESCRIPTION
@370417:

> The intended solution to /training/oESSu only makes sense if you happen to know that white can't castle. Is that grounds for removal? (https://lichess.org/forum/lichess-feedback/httpslichessorgtrainingoessu)

Applied retroactively this would exclude 14k of the 1.8 million existing puzzles.