### PR TITLE
Better underpromotion tagging

### DIFF
--- a/tagger/cook.py
+++ b/tagger/cook.py
@@ -1,5 +1,4 @@
 import logging
-from os import posix_fadvise
 
 from typing import List, Optional, Union
 import chess
@@ -115,7 +114,8 @@ def cook(puzzle: Puzzle) -> List[TagKind]:
 
     if promotion(puzzle):
         tags.append("promotion")
-        if under_promotion(puzzle):
+    
+    if under_promotion(puzzle):
             tags.append("underPromotion")
 
     if capturing_defender(puzzle):
@@ -594,7 +594,9 @@ def promotion(puzzle: Puzzle) -> bool:
 
 def under_promotion(puzzle: Puzzle) -> bool:
     for node in puzzle.mainline[1::2]:
-        if node.move.promotion and node.move.promotion != QUEEN:
+        if node.board().is_checkmate():
+            return True if node.move.promotion == KNIGHT else False
+        elif node.move.promotion and node.move.promotion != QUEEN:
             return True
     return False
 

--- a/tagger/test.py
+++ b/tagger/test.py
@@ -197,6 +197,22 @@ class TestTagger(unittest.TestCase):
         self.assertFalse(cook.queenside_attack(make("Zk4Jr", "3rr1k1/p5pp/2p5/8/1P1bbp2/P1PP1B2/6PP/RK3R2 w - - 0 28", "c3d4 e4d3 b1b2 d3f1")))
         self.assertFalse(cook.queenside_attack(make("umd5a", "r4r1k/5p1p/5qp1/p3b1RP/1p3P2/8/PP1BQ3/2K4R w - - 0 32", "g5e5 f6c6 c1d1 c6h1")))
 
+    def test_underpromotion(self):
+        #unnecessary underpromotion to rook with mate
+        self.assertFalse(cook.under_promotion(make("1nFrQ", "8/1Pp3p1/8/2p5/2P5/5kbp/3p4/7K w - - 0 52", "b7b8q d2d1r")))
+        #underpromotion to knight with mate
+        self.assertTrue(cook.under_promotion(make("2WyFZ", "3R3r/p1P1kp1b/4pnpp/7P/6P1/2p5/P4P2/3R2K1 b - - 0 31", "c3c2 c7c8n")))
+        #Necessary underpromotions to knight, rook & bishop:
+        self.assertTrue(cook.under_promotion(make("0Xyxz", "6k1/p7/4pr2/2P3r1/4Bp1q/1Q3PpP/P4bP1/3R1R1K w - - 1 33", "d1d7 h4h3 g2h3 g3g2 h1h2 g2f1n h2h1 g5g1")))
+        self.assertTrue(cook.under_promotion(make("AB2ON", "R7/P7/8/8/6k1/7p/r7/5K2 b - - 0 51", "g4g3 a8g8 g3h2 a7a8r")))
+        self.assertTrue(cook.under_promotion(make("DzdfL", "6k1/P5P1/1n4K1/8/8/8/8/8 b - - 2 68", "b6c8 a7a8b c8e7 g6f6")))
+        #underpromotion to bishop with mate
+        self.assertFalse(cook.under_promotion(make("iLgxo", "3B4/1pp5/p1b1B3/P3Q1N1/1P5k/2P5/R3R1p1/1q4K1 w - - 2 39", "g1h2 g2g1b")))
+        #promotion to queen with mate(also possible with rook)
+        self.assertFalse(cook.under_promotion(make("00ueM", "2kr4/2pR4/2P1K1P1/8/8/p3n3/8/8 b - - 1 49", "a3a2 d7d8 c8d8 g6g7 a2a1q g7g8q")))
+        self.assertFalse(cook.under_promotion(make("zzzc4", "3r3k/p5pp/8/5R2/1BQ1p3/P3q3/Bb4PP/6K1 w - - 0 28", "g1f1 d8d1 b4e1 e3e1")))
+
+
 class TestUtil(unittest.TestCase):
 
     def test_trapped(self):

--- a/tagger/test.py
+++ b/tagger/test.py
@@ -202,7 +202,7 @@ class TestTagger(unittest.TestCase):
         self.assertFalse(cook.under_promotion(make("1nFrQ", "8/1Pp3p1/8/2p5/2P5/5kbp/3p4/7K w - - 0 52", "b7b8q d2d1r")))
         #underpromotion to knight with mate
         self.assertTrue(cook.under_promotion(make("2WyFZ", "3R3r/p1P1kp1b/4pnpp/7P/6P1/2p5/P4P2/3R2K1 b - - 0 31", "c3c2 c7c8n")))
-        #Necessary underpromotions to knight, rook & bishop:
+        #Necessary underpromotions to knight, rook & bishop respectively:-
         self.assertTrue(cook.under_promotion(make("0Xyxz", "6k1/p7/4pr2/2P3r1/4Bp1q/1Q3PpP/P4bP1/3R1R1K w - - 1 33", "d1d7 h4h3 g2h3 g3g2 h1h2 g2f1n h2h1 g5g1")))
         self.assertTrue(cook.under_promotion(make("AB2ON", "R7/P7/8/8/6k1/7p/r7/5K2 b - - 0 51", "g4g3 a8g8 g3h2 a7a8r")))
         self.assertTrue(cook.under_promotion(make("DzdfL", "6k1/P5P1/1n4K1/8/8/8/8/8 b - - 2 68", "b6c8 a7a8b c8e7 g6f6")))
@@ -210,7 +210,6 @@ class TestTagger(unittest.TestCase):
         self.assertFalse(cook.under_promotion(make("iLgxo", "3B4/1pp5/p1b1B3/P3Q1N1/1P5k/2P5/R3R1p1/1q4K1 w - - 2 39", "g1h2 g2g1b")))
         #promotion to queen with mate(also possible with rook)
         self.assertFalse(cook.under_promotion(make("00ueM", "2kr4/2pR4/2P1K1P1/8/8/p3n3/8/8 b - - 1 49", "a3a2 d7d8 c8d8 g6g7 a2a1q g7g8q")))
-        self.assertFalse(cook.under_promotion(make("zzzc4", "3r3k/p5pp/8/5R2/1BQ1p3/P3q3/Bb4PP/6K1 w - - 0 28", "g1f1 d8d1 b4e1 e3e1")))
 
 
 class TestUtil(unittest.TestCase):


### PR DESCRIPTION
The problem: Stockfish sometimes get flashy and suggests underpromotions to rook/bishop for mate even if promotion to queen does the job. These puzzles are unnecessarily tagged with underpromotions. Example: https://lichess.org/training/1nFrQ

The use case: Some of these puzzles have had the puzzle tag removed (I assume through voting) but a lot of them (46/552=8.3% of underpromotion puzzles) still exist in the puzzledb. If I'm sifting through the db (or even lichess) looking for underpromotion problems, I presume that underpromotion is **the only solution** as opposed to being _one of the possible solutions_.

The solution: Therefore, I've modified the code to only tag promotions to knight with mate as underpromotions (Queen promotions can do the job of the rook or bishop but not the knight). If it's not a mate then the logic remains as it was before. I've also added some tests for the function.