### PR TITLE
Expand multipv search for matein1s

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -13,7 +13,7 @@ from chess import Move, Color
 from chess.engine import SimpleEngine, Mate, Cp, Score, PovScore
 from chess.pgn import Game, ChildNode
 from typing import List, Optional, Union, Set
-from util import get_next_move_pair, material_count, material_diff, is_up_in_material, maximum_castling_rights, win_chances
+from util import get_next_move_pair, material_count, material_diff, is_up_in_material, maximum_castling_rights, win_chances, count_mates
 from server import Server
 
 version = 48
@@ -40,7 +40,8 @@ class Generator:
         if pair.second.score == Mate(1):
             # if there's more than one mate in one, gotta look if the best non-mating move is bad enough
             logger.debug('Looking for best non-mating move...')
-            info = self.engine.analyse(pair.node.board(), multipv = 5, limit = pair_limit)
+            mates = count_mates(copy.deepcopy(pair.node.board()))
+            info = self.engine.analyse(pair.node.board(), multipv = mates + 1, limit = pair_limit)
             for score in [pv["score"].pov(pair.winner) for pv in info]:
                 if score < Mate(1) and win_chances(score) > non_mate_win_threshold:
                     return False

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -42,8 +42,9 @@ class Generator:
             logger.debug('Looking for best non-mating move...')
             mates = count_mates(copy.deepcopy(pair.node.board()))
             info = self.engine.analyse(pair.node.board(), multipv = mates + 1, limit = pair_limit)
-            for score in [pv["score"].pov(pair.winner) for pv in info]:
-                if score < Mate(1) and win_chances(score) > non_mate_win_threshold:
+            scores =  [pv["score"].pov(pair.winner) for pv in info]
+            # the first non-matein1 move is the last element
+            if scores[-1] < Mate(1) and win_chances(scores[-1]) > non_mate_win_threshold:
                     return False
             return True
         return False

--- a/generator/util.py
+++ b/generator/util.py
@@ -68,6 +68,15 @@ def time_control_tier(line: str) -> Optional[int]:
         return 0
     except:
         return 0
+    
+def count_mates(board:chess.Board) -> int:
+    mates = 0
+    for move in board.legal_moves:
+        board.push(move)
+        if board.is_checkmate():
+            mates += 1
+        board.pop()
+    return mates
 
 def rating_tier(line: str) -> Optional[int]:
     if not line.startswith("[WhiteElo ") and not line.startswith("[BlackElo "):


### PR DESCRIPTION
Currently, if a puzzle candidate has >5 possible mates in 1, https://github.com/ornicar/lichess-puzzler/blob/6e64dbcf31cb56841c784c772bff7d0166f59396/generator/generator.py#L43-L47 will return true and it becomes a valid puzzle even if there is a mate in 2 at pv=6 because multipv=5 is hard-coded.

Example: https://lichess.org/training/c2XBo. Move the rook anywhere on the b-file(b3,4,5,6,7,8) and it is mate in 1. However, you can also move it to b1 or a2 for a mate in 2. We don't see this because we're limited at multlipv=5.

We need to search deeper for the first non-mate in 1 move and get its eval to deem whether the puzzle is a good candidate.

I have found 1288 bad matein1 puzzles in the current set that should be removed. https://gist.github.com/allanjoseph98/98c40e628e4310f652d3d342e5236b61